### PR TITLE
Escape problematic characters in .tsv output file

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/extract/cards.go
+++ b/pkg/extract/cards.go
@@ -46,6 +46,15 @@ func (e *ExtractCards) mediaOutputDir() string {
 	return path.Join(path.Dir(e.ForeignSubtitlesFile), e.outputBase()+".media")
 }
 
+func escape(s string) string {
+	// https://datatracker.ietf.org/doc/html/rfc4180.html#section-2
+	if strings.Contains(s, `"`) || strings.Contains(s, "\t") || strings.Contains(s, "\n") {
+		var quoted = strings.ReplaceAll(s, `"`, `""`)
+		return fmt.Sprintf(`"%s"`, quoted)
+	}
+	return s
+}
+
 func (e *ExtractCards) Execute() error {
 	var nativeSubs *subs.Subtitles
 
@@ -78,16 +87,16 @@ func (e *ExtractCards) Execute() error {
 	}
 
 	return ExportItems(foreignSubs, nativeSubs, e.outputBase(), e.MediaSourceFile, mediaPrefix, func(item *ExportedItem) error {
-		fmt.Fprintf(outStream, "%s\t", item.Sound)
-		fmt.Fprintf(outStream, "%s\t", item.Time)
-		fmt.Fprintf(outStream, "%s\t", item.Source)
-		fmt.Fprintf(outStream, "%s\t", item.Image)
-		fmt.Fprintf(outStream, "%s\t", item.ForeignCurr)
-		fmt.Fprintf(outStream, "%s\t", item.NativeCurr)
-		fmt.Fprintf(outStream, "%s\t", item.ForeignPrev)
-		fmt.Fprintf(outStream, "%s\t", item.NativePrev)
-		fmt.Fprintf(outStream, "%s\t", item.ForeignNext)
-		fmt.Fprintf(outStream, "%s\n", item.NativeNext)
+		fmt.Fprintf(outStream, "%s\t", escape(item.Sound))
+		fmt.Fprintf(outStream, "%s\t", escape(item.Time))
+		fmt.Fprintf(outStream, "%s\t", escape(item.Source))
+		fmt.Fprintf(outStream, "%s\t", escape(item.Image))
+		fmt.Fprintf(outStream, "%s\t", escape(item.ForeignCurr))
+		fmt.Fprintf(outStream, "%s\t", escape(item.NativeCurr))
+		fmt.Fprintf(outStream, "%s\t", escape(item.ForeignPrev))
+		fmt.Fprintf(outStream, "%s\t", escape(item.NativePrev))
+		fmt.Fprintf(outStream, "%s\t", escape(item.ForeignNext))
+		fmt.Fprintf(outStream, "%s\n", escape(item.NativeNext))
 		return nil
 	})
 }


### PR DESCRIPTION
Hi 👋 

I had `"` characters in .srt subtitles breaking the import of .tsv files due to lack of rfc4180 escaping.   This PR adds the escaping.